### PR TITLE
chore: bump application version from 4.6.1 to 4.6.2.

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-react-boilerplate",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-react-boilerplate",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-react-boilerplate",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "A foundation for scalable desktop apps",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the release app package metadata to version 4.6.2.